### PR TITLE
protect cout with mutex to prevent interleaving character output

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -166,6 +166,7 @@ sql::mysql::MySQL_Driver      *driver;
 sql::Connection               *download_con;
 sql::Connection               *processing_con;
 std::mutex                    queue_mutex;
+std::mutex                    cout_mutex;
 int parsed_files              = 0;
 // Queues for delayed mod, requirement, property and socket insertion
 std::deque<std::vector<Mod>>         mod_queue         = std::deque<std::vector<Mod>>();
@@ -213,7 +214,9 @@ void print_sql_error( const sql::SQLException e ) {
         << __LINE__ << std::endl << "# ERR: " << e.what()
         << std::endl << " (MySQL error code: " << e.getErrorCode()
         << std::endl << ", SQLState: " << e.getSQLState() << " )";
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
 }
 
 /**
@@ -249,22 +252,28 @@ std::string download_JSON( const std::string change_id ) {
         /* always cleanup */
         curl_easy_cleanup( curl );
         fclose( fp );
+
+        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+        msg << stamp( __FUNCTION__ ) << "Downloaded " << change_id 
+            << " (" << std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() / 1000000.0
+            << "sec )";
+        cout_mutex.lock();
+        std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
+        msg.str( "" );
+
         if ( res != CURLE_OK ) {
             msg << stamp( __FUNCTION__ ) << "There was an error downloading " 
                 << change_id << ": " << curl_easy_strerror( res )
                 << ", retrying";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             download_JSON( change_id );
         } else {
             return path;
         }
-        std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-        msg << stamp( __FUNCTION__ ) << "Downloaded " << change_id 
-            << " (" << std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() / 1000000.0
-            << "sec )";
-        std::cout << msg.str() << std::endl;
-        msg.str( "" );
     }
     return "";
 }
@@ -502,12 +511,16 @@ void threaded_insert( const std::string query ) {
     } catch ( sql::SQLException &e ) {
         print_sql_error( e );
         msg << query;
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
         msg.str( "" );
         // If query failed, wait 5 seconds and retry
         std::this_thread::sleep_for(std::chrono::milliseconds( 5000 ));
         msg << "Retrying" << std::endl;
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
         msg.str( "" );
         // Cleanup
         if ( stmt ) {
@@ -542,12 +555,16 @@ void parse_JSON( const std::string path ) {
     std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
     if ( !std::ifstream( path )) {
         msg << stamp( __FUNCTION__ ) << "File does not exist, skipping: " << path;
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
         msg.str( "" );
         return;
     }
     msg << stamp( __FUNCTION__ ) << "Reading data file: " << path;
+    cout_mutex.lock();
     std::cout << msg.str() << std::endl;
+    cout_mutex.unlock();
     msg.str( "" );
     std::ifstream file( path.c_str() );
     std::stringstream sstr;
@@ -558,7 +575,9 @@ void parse_JSON( const std::string path ) {
     time_loading_JSON = ( std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() / 1000000.0 );
     msg << stamp( __FUNCTION__ ) << "Loaded: " << path << " in " 
         << time_loading_JSON << " sec";
+    cout_mutex.lock();
     std::cout << msg.str() << std::endl;
+    cout_mutex.unlock();
     msg.str( "" );
     // MySQL statements used for insertions
     begin = std::chrono::steady_clock::now();
@@ -1116,7 +1135,9 @@ void parse_JSON( const std::string path ) {
             << ", properties: " << parsed_properties.size() 
             << ", requirements: " << parsed_requirements.size() 
             << ", sockets: " << parsed_sockets.size();
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
         msg.str( "" );
         // Empty arrays
         parsed_mods.clear();
@@ -1183,7 +1204,9 @@ void mod_loop() {
             printed_wait = false;
             msg << stamp( __FUNCTION__ ) << "Inserting mod batch (" 
                 << mod_queue.size() << " to go)";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             std::vector<Mod> mods = mod_queue.front();
             inserting_mods = true;
@@ -1200,7 +1223,9 @@ void mod_loop() {
                 threaded_insert( "LOAD DATA CONCURRENT INFILE 'mods.txt' REPLACE INTO TABLE `Mods` FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\"' LINES TERMINATED BY '\n'" );
             } else {
                 msg << stamp( __FUNCTION__ ) << "Could not open file";
+                cout_mutex.lock();
                 std::cout << msg.str() << std::endl;
+                cout_mutex.unlock();
                 msg.str( "" );
             }
             std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
@@ -1211,7 +1236,9 @@ void mod_loop() {
         // If we are out of entries to insert
         if ( !interrupt && !printed_wait ) {
             msg << stamp( __FUNCTION__ ) << "Waiting for mods to insert";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             printed_wait = true;
         }
@@ -1234,12 +1261,14 @@ void requirement_loop() {
     while ( true ) {
         if ( requirement_queue.size() == 0 && end_program ) {
             return;
-        }   
+        }
         if ( !inserting_requirements && requirement_queue.size() > 0 ) {
             printed_wait = false;
             msg << stamp( __FUNCTION__ ) << "Inserting requirement batch (" 
                 << requirement_queue.size() << " to go)";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             std::vector<Requirement> requirements = requirement_queue.front();
             inserting_requirements = true;
@@ -1256,7 +1285,9 @@ void requirement_loop() {
                 threaded_insert( "LOAD DATA CONCURRENT INFILE 'requirements.txt' REPLACE INTO TABLE `Requirements` FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\"' LINES TERMINATED BY '\n'" );
             } else {
                 msg << stamp( __FUNCTION__ ) << "Could not open file";
+                cout_mutex.lock();
                 std::cout << msg.str() << std::endl;
+                cout_mutex.unlock();
                 msg.str( "" );
             }
             std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
@@ -1267,7 +1298,9 @@ void requirement_loop() {
         // If we are out of entries to insert
         if ( !interrupt && !printed_wait ) {
             msg << stamp( __FUNCTION__ ) << "Waiting for requirements to insert";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             printed_wait = true;
         }
@@ -1295,7 +1328,9 @@ void property_loop() {
             printed_wait = false;
             msg << stamp( __FUNCTION__ ) << "Inserting property batch (" 
                 << property_queue.size() << " to go)";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             std::vector<Property> properties = property_queue.front();
             inserting_properties = true;
@@ -1312,7 +1347,9 @@ void property_loop() {
                 threaded_insert( "LOAD DATA CONCURRENT INFILE 'properties.txt' REPLACE INTO TABLE `Properties` FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\"' LINES TERMINATED BY '\n'" );
             } else {
                 msg << stamp( __FUNCTION__ ) << "Could not open file";
+                cout_mutex.lock();
                 std::cout << msg.str() << std::endl;
+                cout_mutex.unlock();
                 msg.str( "" );
             }
             std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
@@ -1323,7 +1360,9 @@ void property_loop() {
         // If we are out of entries to insert
         if ( !interrupt && !printed_wait ) {
             msg << stamp( __FUNCTION__ ) << "Waiting for property to insert";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             printed_wait = true;
         }
@@ -1351,7 +1390,9 @@ void socket_loop() {
             printed_wait = false;
             msg << stamp( __FUNCTION__ ) << "Inserting socket batch (" 
                 << socket_queue.size() << " to go)";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             std::vector<Socket> sockets = socket_queue.front();
             inserting_sockets = true;
@@ -1368,7 +1409,9 @@ void socket_loop() {
                 threaded_insert( "LOAD DATA CONCURRENT INFILE 'sockets.txt' REPLACE INTO TABLE `Sockets` FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\"' LINES TERMINATED BY '\n'" );
             } else {
                 msg << stamp( __FUNCTION__ ) << "Could not open file";
+                cout_mutex.lock();
                 std::cout << msg.str() << std::endl;
+                cout_mutex.unlock();
                 msg.str( "" );
             }
             std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
@@ -1379,7 +1422,9 @@ void socket_loop() {
         // If we are out of entries to insert
         if ( !interrupt && !printed_wait ) {
             msg << stamp( __FUNCTION__ ) << "Waiting for socket to insert";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             printed_wait = true;
         }
@@ -1405,21 +1450,44 @@ void download_loop() {
             std::string path = download_JSON( next_change_id );
             // Add file to the queue
             std::lock_guard<std::mutex> lock( queue_mutex );
-            downloaded_files.push_back( next_change_id );
 
             // Read JSON file to extract next change id
             std::ifstream file( path.c_str() );
             std::stringstream sstr;
             sstr << file.rdbuf();
+
             document.Parse( sstr.str().c_str());
+
             // If document is not valid, do not change the change id
-            if ( !document.IsObject() || document["next_change_id"].IsNull()) {
-                msg << stamp( __FUNCTION__ ) << "Change ID " 
-                    << next_change_id << " empty";
+            if ( !document.IsObject() || !document.HasMember("next_change_id") || document["next_change_id"].IsNull()) {
+                msg << stamp( __FUNCTION__ ) << "Change ID "
+                    << next_change_id << " has missing next_change_id or invalid JSON. Waiting 20 seconds to retry.";
+                cout_mutex.lock();
                 std::cout << msg.str() << std::endl;
+                cout_mutex.unlock();
                 msg.str( "" );
+
+                msg << stamp( __FUNCTION__ ) << "Change ID " << next_change_id;
+                if (!document.IsObject()) {
+                    msg <<  " was not an object.";
+                } else if (!document.HasMember("next_change_id")) {
+                    msg << " did not have a next_change_id member.";
+                } else if (document["next_change_id"].IsNull()) {
+                    msg << " has null value for next_change_id";
+                }
+
+                cout_mutex.lock();
+                std::cout << msg.str() << std::endl;
+                cout_mutex.unlock();
+                msg.str( "" );
+
+                // Probably getting rate limited. Wait 20 seconds.
+                std::this_thread::sleep_for(std::chrono::milliseconds( 20000 ));
                 continue;
             }
+
+            downloaded_files.push_back( next_change_id );
+
             const rapidjson::Value& change_id = document["next_change_id"];
             next_change_id = (char*) change_id.GetString();
 
@@ -1493,7 +1561,9 @@ void processing_loop() {
                 << " over " << round( time_sec_conv.amount, 2 ) << " " 
                 << time_sec_conv.unit << " at " << MAGENTA << speed 
                 << RESET << " insert/s";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             msg << stamp( __FUNCTION__ ) << "Time profile: "
                 << "JSON: " << round( time_loading_JSON, 2 ) << " sec, "
@@ -1503,7 +1573,9 @@ void processing_loop() {
                 << std::ceil( time_other * 100 / time_sec ) << " %), "
                 << "remain: " << round( remaning_time, 2 ) << " sec ("
                 << std::ceil( remaning_time * 100 / time_sec ) << " %)";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             msg << stamp( __FUNCTION__ ) 
                 << "Total entries processed: " << total_sum 
@@ -1514,11 +1586,15 @@ void processing_loop() {
                 << " over " << round( total_time_conv.amount, 2 ) << " " 
                 << total_time_conv.unit << " at " << MAGENTA << total_speed 
                 << RESET << " insert/s";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             msg << stamp( __FUNCTION__ ) 
                 << downloaded_files.size() << " files to be processed";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             // If we should log statistics to file
             if ( LOG_STAT ) {
@@ -1536,7 +1612,9 @@ void processing_loop() {
         // If we are out of files to parse
         if ( !interrupt && !printed_wait ) {
             msg << stamp( __FUNCTION__ ) << "Waiting for files to process";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             printed_wait = true;
         }
@@ -1562,7 +1640,9 @@ void cleanup( const int s ) {
     msg << stamp( __FUNCTION__ ) << RED 
         << "Caught interrupt signal, exiting gracefully" 
         << RESET;
+    cout_mutex.lock();
     std::cout << msg.str() << std::endl;
+    cout_mutex.unlock();
     msg.str( "" );
     while ( !end_program ) {
         std::this_thread::sleep_for(std::chrono::milliseconds( 100 ));
@@ -1576,7 +1656,9 @@ void cleanup( const int s ) {
                   << "Waiting for " << mod_queue_size 
                   << " mod batch(es) to end program" 
                   << RESET;
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
         msg.str( "" );
     }
     if ( property_queue_size > 0 ) {
@@ -1584,7 +1666,9 @@ void cleanup( const int s ) {
                   << "Waiting for " << property_queue_size 
                   << " property batch(es) to end program"
                   << RESET;
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
         msg.str( "" );
     }
     if ( requirement_queue_size > 0 ) {
@@ -1592,7 +1676,9 @@ void cleanup( const int s ) {
                   << "Waiting for " << requirement_queue_size 
                   << " requirement batch(es) to end program"
                   << RESET;
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
         msg.str( "" );
     }
     if ( socket_queue_size > 0 ) {
@@ -1600,7 +1686,9 @@ void cleanup( const int s ) {
             << "Waiting for " << socket_queue_size 
             << " socket batch(es) to end program"
             << RESET;
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
         msg.str( "" );
     }
 }
@@ -1631,7 +1719,8 @@ void bench( const std::string path ) {
         time_properties + time_sockets + time_requirements + time_other );
     Time total_time_conv = format_time( total_time * 1000.0 );
     Time time_sec_conv   = format_time( time_sec * 1000.0 );
-    
+
+    cout_mutex.lock();
     std::cout << stamp( __FUNCTION__ ) << "Entries total: " 
               << sum << ", added: " << GREEN
               << item_added << RESET << ", removed: " << RED << item_removed 
@@ -1666,6 +1755,7 @@ void bench( const std::string path ) {
               << " over " << round( total_time_conv.amount, 2 ) << " " 
               << total_time_conv.unit << " at " << MAGENTA << total_speed 
               << RESET << " insert/s" << std::endl;
+    cout_mutex.unlock();
 }
  
  /**
@@ -1720,7 +1810,9 @@ int main( int argc, char* argv[]) {
         float time_DB = ( std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() / 1000000.0 );
         msg << stamp( __FUNCTION__ ) << "Connected to DB in " 
             << time_DB << " sec";
+        cout_mutex.lock();
         std::cout << msg.str() << std::endl;
+        cout_mutex.unlock();
         msg.str( "" );
 
         // Catch interrupt signal
@@ -1736,27 +1828,37 @@ int main( int argc, char* argv[]) {
             next_change_id = argv[1];
             msg << stamp( __FUNCTION__ ) << "Resuming from input chunk " 
                 << "(" << next_change_id << ")";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
         } else {
             msg << stamp( __FUNCTION__ ) << "Checking last downloaded chunk";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
             next_change_id = last_downloaded_chunk();
         }
         if ( next_change_id.compare( "" ) != 0 ) {
             if ( next_change_id.compare( "-1" ) == 0 ) {
                 msg << stamp( __FUNCTION__ ) << "New indexation: ";
+                cout_mutex.lock();
                 std::cout << msg.str() << std::endl;
+                cout_mutex.unlock();
                 msg.str( "" );
             } else {
                 msg << stamp( __FUNCTION__ ) << "Next change id: " 
                     << next_change_id;
+                cout_mutex.lock();
                 std::cout << msg.str() << std::endl;
+                cout_mutex.unlock();
                 msg.str( "" );
                 msg << stamp( __FUNCTION__ ) 
                     << downloaded_files.size() << " files to be processed";
+                cout_mutex.lock();
                 std::cout << msg.str() << std::endl;
+                cout_mutex.unlock();
                 msg.str( "" );
             }
             // Start insertion threads
@@ -1771,7 +1873,9 @@ int main( int argc, char* argv[]) {
         } else {
             msg << stamp( __FUNCTION__ ) 
                 << "There was an error fetching next change id";
+            cout_mutex.lock();
             std::cout << msg.str() << std::endl;
+            cout_mutex.unlock();
             msg.str( "" );
         }
 


### PR DESCRIPTION
I had a few issues getting this up and working last night. This fixes a few of them.

First issue was interleaved characters due to multiple threads concurrently calling cout. Resolved this by protecting calls to cout with a mutex.

The other issue is that once you are rate-limited, the program behaved incorrectly in three ways: 

When you get rate limited, you receive a JSON file that does not contain a 'next_change_id' member, causing `document["next_change_id"].IsNull()` to crash the program on a failed assertion inside rapidjson. Now it will check for presence of next_change_id before checking its nullity.

Also, it would push an invalid changeset file (containing only an error about rate limits) back into the `downloaded_files` deque. 

Lastly, it did not introduce any sort of delay, it would just spam redownload the rate limit error without a sleep.


This PR should resolve all of those issues. I've never really written c++ before, so there might have been a more idiomatic way of resolving these issues, but this appears to work.